### PR TITLE
Radhakrishnan | MOBN-2413 | Use xlsx instead of xls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
+                    <version>3.3.2</version>
                     <configuration>
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                         <packagingExcludes>test/**</packagingExcludes>

--- a/src/main/java/org/bahmni/reports/filter/JasperResponseConverter.java
+++ b/src/main/java/org/bahmni/reports/filter/JasperResponseConverter.java
@@ -3,7 +3,7 @@ package org.bahmni.reports.filter;
 import net.sf.dynamicreports.jasper.builder.JasperConcatenatedReportBuilder;
 import net.sf.dynamicreports.jasper.builder.JasperReportBuilder;
 import net.sf.dynamicreports.jasper.builder.export.Exporters;
-import net.sf.dynamicreports.jasper.builder.export.JasperXlsExporterBuilder;
+import net.sf.dynamicreports.jasper.builder.export.JasperXlsxExporterBuilder;
 import net.sf.dynamicreports.report.exception.DRException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,11 +48,11 @@ public class JasperResponseConverter {
                     logger.error(String.format("Invalid Macro Template specified: %s", macroTemplateFile));
                     throw new RuntimeException(EX_INVALID_MACRO_TEMPLATE);
                 }
-                JasperXlsExporterBuilder exporterBuilder = Exporters.xlsExporter(outputStream).setDetectCellType(true);
+                JasperXlsxExporterBuilder exporterBuilder = Exporters.xlsxExporter(outputStream).setDetectCellType(true);
                 exporterBuilder.setKeepWorkbookTemplateSheets(true);
                 exporterBuilder.setWorkbookTemplate(macroTemplateFile.toString());
                 exporterBuilder.addSheetName("Report");
-                concatenatedReportBuilder.toXls(exporterBuilder);
+                concatenatedReportBuilder.toXlsx(exporterBuilder);
                 // boolean delete = templateFile.delete();
                 // if (!delete) {
                 //    logger.warn(String.format("Uploaded report template file not deleted: %s", macroTemplateFile));


### PR DESCRIPTION
https://msfprojects.atlassian.net/browse/MOBN-2413

**Description:**
When generating reports using Bahmni Reports, an error occurs due to an invalid row number exceeding the allowable range in the Excel file (i.e `Invalid row number (65536) outside allowable range (0..65535)` ). This error prevents the successful generation of reports when the number of rows exceeds 65,535.

**Solution**
For report generation, we are using a plugin called `jasper`, Updating the export format from `xls` to `xlsx` solved the issue.

<img width="1728" alt="Screenshot 2024-07-25 at 2 57 32 PM" src="https://github.com/user-attachments/assets/95b25c9d-b095-4dcf-8080-33f1445f0acb">

